### PR TITLE
Adds check for Slack connection to support bundle

### DIFF
--- a/chart/slackernews/templates/troubleshoot/secrets.yaml
+++ b/chart/slackernews/templates/troubleshoot/secrets.yaml
@@ -7,3 +7,12 @@ metadata:
     troubleshoot.sh/kind: preflight
 stringData:
   preflight.yaml: |- {{- include "troubleshoot.preflights" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: slackernews-support-bundle
+  labels: 
+    troubleshoot.sh/kind: support-bundle
+stringData:
+  support-bundle-spec: |- {{- include "troubleshoot.supportBundle" . | nindent 4 }}

--- a/chart/slackernews/templates/troubleshoot/support-bundle.yaml
+++ b/chart/slackernews/templates/troubleshoot/support-bundle.yaml
@@ -1,0 +1,30 @@
+{{- define "troubleshoot.supportBundle" -}}
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: slackernews-support-bundle
+spec:
+  collectors:      
+    - clusterInfo: {}
+    - clusterResources: {}
+    - http:
+        collectorName: slack
+        get:
+          url: https://api.slack.com/methods/api.test
+  analyzers:
+    - textAnalyze:
+        checkName: Slack Accessible
+        fileName: slack.json
+        regex: '"status": 200,'
+        outcomes:
+          - pass:
+              when: "true"
+              message: "Can access the Slack API"
+          - fail:
+              when: "false"
+              message: |
+                Cannot access the Slack API. Check your firewall settings,
+                network policies, and the [Slack status
+                page](https://status.slack.com).
+
+{{- end -}}


### PR DESCRIPTION
TL;DR
-----

Creates a support bundle that also checks Slack connectivity

Details
-------

Incorporates a support bundle with the same checks that the preflight check
includes for checking connectivity to Slack. This is useful since the network
policy and/or firewall rules could change after installation.
