### PR TITLE
Provides metrics on usage

### DIFF
--- a/chart/slackernews/templates/metrics-job.yaml
+++ b/chart/slackernews/templates/metrics-job.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: provide-license-metrics
+spec:
+  schedule: "0 0 * * *"  # Runs at midnight every day
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: curl-container
+            image: curlimages/curl  # Using the official curl image
+            command:
+            - /bin/sh
+            - -c
+            - >
+              curl http://slackernews:3000/api/metrics
+          restartPolicy: OnFailure
+

--- a/chart/slackernews/templates/slackernews-deployment.yaml
+++ b/chart/slackernews/templates/slackernews-deployment.yaml
@@ -50,6 +50,8 @@ spec:
               secretKeyRef:
                 key: "{{ if .Values.slack.existingSecretSlackTokenKey }}{{ .Values.slack.existingSecretTokenKey }}{{ else }}userToken{{ end }}"
                 name: "{{ if .Values.slack.existingSecretName }}{{ .Values.slack.existingSecretName }}{{ else }}slackernews-slack{{ end }}"
+          - name: REPLICATED_ENABLED
+            value: "true"
           - name: INSTALL_METHOD
             value: helm
           - name: SLACKERNEWS_ADMIN_USER_EMAILS
@@ -58,6 +60,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: REPLICATED_ENDPOINT
+            value: "http://replicated:3000"
         ports:
         - containerPort: 3000
           name: http

--- a/slackernews/pages/api/metrics.ts
+++ b/slackernews/pages/api/metrics.ts
@@ -1,20 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { register, collectDefaultMetrics } from 'prom-client';
 import { sendMetrics } from "../../lib/metrics/replicated";
-import { collectUserMetrics, collectLicenseEntitlements, collectVersionMetrics } from "../../lib/metrics/prometheus";
-
-collectDefaultMetrics({ prefix: 'slackernews_' });
 
 export default async function handler(_: NextApiRequest, res: NextApiResponse) {
   // send custom metrics to replicated metrics when sending prometheus metrics
   sendMetrics();
-  
-  // prepare prometheus metrics
-  collectUserMetrics();
-  collectLicenseEntitlements();
-  collectVersionMetrics();
-
-  res.setHeader('Content-type', register.contentType);
-  res.setHeader('Cache-Control', 'no-store');
-  res.send(await register.metrics());
+  res.status(201).end();
 }

--- a/slackernews/pages/api/metrics.ts
+++ b/slackernews/pages/api/metrics.ts
@@ -4,5 +4,5 @@ import { sendMetrics } from "../../lib/metrics/metric";
 export default async function handler(_: NextApiRequest, res: NextApiResponse) {
   // send custom metrics to replicated metrics when sending prometheus metrics
   sendMetrics();
-  res.status(201).end();
+  res.status(200).end();
 }

--- a/slackernews/pages/api/metrics.ts
+++ b/slackernews/pages/api/metrics.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { sendMetrics } from "../../lib/metrics/replicated";
+import { sendMetrics } from "../../lib/metrics/metric";
 
 export default async function handler(_: NextApiRequest, res: NextApiResponse) {
   // send custom metrics to replicated metrics when sending prometheus metrics

--- a/slackernews/pages/api/metrics.ts
+++ b/slackernews/pages/api/metrics.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { register, collectDefaultMetrics } from 'prom-client';
+import { sendMetrics } from "../../lib/metrics/replicated";
+import { collectUserMetrics, collectLicenseEntitlements, collectVersionMetrics } from "../../lib/metrics/prometheus";
+
+collectDefaultMetrics({ prefix: 'slackernews_' });
+
+export default async function handler(_: NextApiRequest, res: NextApiResponse) {
+  // send custom metrics to replicated metrics when sending prometheus metrics
+  sendMetrics();
+  
+  // prepare prometheus metrics
+  collectUserMetrics();
+  collectLicenseEntitlements();
+  collectVersionMetrics();
+
+  res.setHeader('Content-type', register.contentType);
+  res.setHeader('Cache-Control', 'no-store');
+  res.send(await register.metrics());
+}

--- a/slackernews/pages/index.js
+++ b/slackernews/pages/index.js
@@ -8,6 +8,7 @@ import { loadSession } from "../lib/session";
 import { listTopLinks } from "../lib/link";
 import { getParam } from "../lib/param";
 import { listAvailableUserGroups, listUsersInUserGroup } from "../lib/slack";
+import { sendMetrics } from "../lib/metrics/metric";
 import envConfig from "../lib/env-config";
 
 export default function Page({ renderableLinks, nextPageUrl, startCount, isSuperAdmin, isDebugMode }) {
@@ -85,6 +86,8 @@ export async function getServerSideProps(ctx) {
       `/?t=${duration}&p=${parseInt(page) + 1}` :
       `/?p=${parseInt(page) + 1}`
     : null;
+
+  await sendMetrics();
 
   const {showChromePluginTab} = envConfig();
 


### PR DESCRIPTION
TL;DR
-----

Sends custom metrics for daily and monthly users

Details
-------

Adds support for custom metrics to keep track of customer usage against their
license. An update is sent on load of the home page and once a day via a
cron job.
