### PR TITLE
Blocks persistence for trial licenses

### DIFF
--- a/chart/slackernews/templates/_helper.tpl
+++ b/chart/slackernews/templates/_helper.tpl
@@ -46,6 +46,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- and (ne \$licenseType "trial") \$postgresEnabled -}}
+{{- and (ne $licenseType "trial") $postgresEnabled -}}
 {{- end }}
 

--- a/chart/slackernews/templates/_helper.tpl
+++ b/chart/slackernews/templates/_helper.tpl
@@ -37,12 +37,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 
 {{- define "slackernews.persistence.enabled" -}}
-{{- \$licenseType := "prod" -}}
-{{- \$postgresEnabled := .Values.postgres.enabled -}}
+{{- $licenseType := "prod" -}}
+{{- $postgresEnabled := .Values.postgres.enabled -}}
 {{- if hasKey .Values "global" -}}
   {{- if hasKey .Values.global "replicated" -}}
     {{- if hasKey .Values.global.replicated "licenseType" -}}
-      {{- \$licenseType = .Values.global.replicated.licenseType -}}
+      {{- $licenseType = .Values.global.replicated.licenseType -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/chart/slackernews/templates/_helper.tpl
+++ b/chart/slackernews/templates/_helper.tpl
@@ -34,3 +34,18 @@ Selector labels
 app.kubernetes.io/name: {{ include "slackernews.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{- define "slackernews.persistence.enabled" -}}
+{{- \$licenseType := "prod" -}}
+{{- \$postgresEnabled := .Values.postgres.enabled -}}
+{{- if hasKey .Values "global" -}}
+  {{- if hasKey .Values.global "replicated" -}}
+    {{- if hasKey .Values.global.replicated "licenseType" -}}
+      {{- \$licenseType = .Values.global.replicated.licenseType -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- and (ne \$licenseType "trial") \$postgresEnabled -}}
+{{- end }}
+

--- a/chart/slackernews/templates/postgres-statefulset.yaml
+++ b/chart/slackernews/templates/postgres-statefulset.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.postgres.deploy_postgres true }}
+{{- if eq (include "slackernews.persistence.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
TL;DR
-----

Uses the license type to restrict the use of Postgres

Details
-------

Show a sample use of the Replicated license in Helm templates to not enable
Postgres if the license is a trial license.